### PR TITLE
Add the support of  "vars" overriding "environment" variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ It is based on [py-passbolt library](https://pypi.org/project/py-passbolt/).
 | PASSBOLT_NEW_RESOURCE_PASSWORD_LENGTH        | Password length when creating a new resource                                                                         | Default value: 20                       |
 | PASSBOLT_NEW_RESOURCE_PASSWORD_SPECIAL_CHARS | The plugin creates only alphanumerics characters by default. Set this variable to true to include special characters | true / false (default)                  |
 
+The environment variables are overridable by variable or the --extra-vars option 
+
 **Note**: How to set OpenPGP key in one-line format:
 
 Linux:

--- a/plugins/lookup/passbolt.py
+++ b/plugins/lookup/passbolt.py
@@ -88,6 +88,19 @@ display = Display()
 
 
 class LookupModule(LookupBase):
+    def _get_value(
+        self, selected_variable, variables, environment_variables, default=str()
+    ):
+        variable = variables.get(selected_variable, None)
+        if variable is None:
+            return self._get_env_value(
+                selected_variable=selected_variable,
+                environment_variables=environment_variables,
+                default=default,
+            )
+        else:
+            return variable
+
     def _get_env_value(self, selected_variable, environment_variables, default=str()):
         if not environment_variables:
             return environ.get(selected_variable, default)
@@ -170,39 +183,39 @@ class LookupModule(LookupBase):
 
     def _get_config(self, variables):
         return {
-            "base_url": self._get_env_value(
-                "PASSBOLT_BASE_URL", variables.get("environment")
+            "base_url": self._get_value(
+                "PASSBOLT_BASE_URL", variables, variables.get("environment")
             ),
-            "private_key": self._get_env_value(
-                "PASSBOLT_PRIVATE_KEY", variables.get("environment")
+            "private_key": self._get_value(
+                "PASSBOLT_PRIVATE_KEY", variables, variables.get("environment")
             ),
-            "passphrase": self._get_env_value(
-                "PASSBOLT_PASSPHRASE", variables.get("environment")
+            "passphrase": self._get_value(
+                "PASSBOLT_PASSPHRASE", variables, variables.get("environment")
             ),
-            "gpg_binary": self._get_env_value(
-                "PASSBOLT_GPG_BINARY", variables.get("environment"), default="gpg"
+            "gpg_binary": self._get_value(
+                "PASSBOLT_GPG_BINARY", variables, variables.get("environment"), default="gpg"
             ),
-            "gpg_library": self._get_env_value(
-                "PASSBOLT_GPG_LIBRARY", variables.get("environment"), default="PGPy"
+            "gpg_library": self._get_value(
+                "PASSBOLT_GPG_LIBRARY", variables, variables.get("environment"), default="PGPy"
             ),
-            "fingerprint": self._get_env_value(
-                "PASSBOLT_FINGERPRINT", variables.get("environment")
+            "fingerprint": self._get_value(
+                "PASSBOLT_FINGERPRINT", variables, variables.get("environment")
             ),
-            "verify": self._get_env_value(
-                "PASSBOLT_VERIFY", variables.get("verify"), default=True
+            "verify": self._get_value(
+                "PASSBOLT_VERIFY", variables, variables.get("environment"), default=True
             ),
-            "create_new_resource": self._get_env_value(
-                "PASSBOLT_CREATE_NEW_RESOURCE",
+            "create_new_resource": self._get_value(
+                "PASSBOLT_CREATE_NEW_RESOURCE", variables,
                 variables.get("environment"),
                 default=False,
             ),
-            "new_resource_password_length": self._get_env_value(
-                "PASSBOLT_NEW_RESOURCE_PASSWORD_LENGTH",
+            "new_resource_password_length": self._get_value(
+                "PASSBOLT_NEW_RESOURCE_PASSWORD_LENGTH", variables,
                 variables.get("environment"),
                 default=20,
             ),
-            "new_resource_password_special_chars": self._get_env_value(
-                "PASSBOLT_NEW_RESOURCE_PASSWORD_SPECIAL_CHARS",
+            "new_resource_password_special_chars": self._get_value(
+                "PASSBOLT_NEW_RESOURCE_PASSWORD_SPECIAL_CHARS", variables,
                 variables.get("environment"),
                 default=False,
             ),
@@ -258,7 +271,6 @@ class LookupModule(LookupBase):
         return resource
 
     def run(self, terms, variables=None, **kwargs):
-
         ret = []
 
         self.set_options(var_options=variables, direct=kwargs)


### PR DESCRIPTION
In our team we use the git versioning and we want to use the gnupg library but our GPG fingerprint differs, so i add the possibility to override environment vars with "local variable" not present in our git repository