### PR TITLE
Use PASSBOLT_NEW_RESOURCE_PASSWORD_LENGTH when generating passwords

### DIFF
--- a/plugins/lookup/passbolt.py
+++ b/plugins/lookup/passbolt.py
@@ -120,7 +120,7 @@ class LookupModule(LookupBase):
             == "true"
         ):
             characters += string.punctuation
-        return "".join(secrets.choice(characters) for i in range(20))
+        return "".join(secrets.choice(characters) for i in range(self.dict_config.get("new_resource_password_length")))
 
     def _create_new_resource(self, kwargs):
         new_password = self._create_new_password()


### PR DESCRIPTION
While `$PASSBOLT_NEW_RESOURCE_PASSWORD_LENGTH` was correctly read from the environment, its value was effectively never used when generating the actual passwords for new resources.