### PR TITLE
Update README.md, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add to requirements.txt:
 py-passbolt
 ```
 
-Add to requirements.txt:
+Add to requirements.yml:
 
 ```
 collections:


### PR DESCRIPTION
The Ansible collection requirements should land in the requirements.yml file and not the requirements.txt file.