### PR TITLE
Fix OS environment variables ignored when Ansible environment is set (Fixes #13)

### DIFF
--- a/plugins/lookup/passbolt.py
+++ b/plugins/lookup/passbolt.py
@@ -102,19 +102,20 @@ class LookupModule(LookupBase):
             return variable
 
     def _get_env_value(self, selected_variable, environment_variables, default=str()):
-        if not environment_variables:
-            return environ.get(selected_variable, default)
-        else:
-            return self._templar.template(
-                next(
-                    (
-                        item.get(selected_variable)
-                        for item in environment_variables
-                        if item.get(selected_variable)
-                    ),
-                    default,
-                )
+        variable = environ.get(selected_variable, None)
+        if variable is not None:
+            default = variable
+        variable = self._templar.template(
+            next(
+                (
+                    item.get(selected_variable)
+                    for item in environment_variables
+                    if item.get(selected_variable)
+                ),
+                default,
             )
+        )
+        return variable
 
     def _search(self, item, kwargs):
         res = 0


### PR DESCRIPTION
OS environment variable, if found, is now set as the default value when looking for environment variables defined within Ansible. If PASSBOLT environment variables are defined within Ansible, they will take precedence, if not found, it will fallback to the OS environment and if still not found, it will fall back to the hardcoded defaults.
This should fix #13.